### PR TITLE
Fix "unzip" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ vec![vec![🐱, 🐶, 🐦], vec![🍰, 🍔, 🍬]]
 
 [unzip](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.unzip)
 ```rust
-let (animals, foods): (Vec<Animal>, Vec<Food>) = 
+let (animals, food): (Vec<Animal>, Vec<Food>) = 
 [(🐱, 🍰), (🐶, 🍔), (🐦, 🍬)]
     .iter()
-    .unzip(food.iter());
+    .cloned()
+    .unzip();
 
-println!("{:?}", left); // [🐱, 🐶, 🐦]
-println!("{:?}", right); // [🍰, 🍔, 🍬]
+println!("{:?}", animals); // [🐱, 🐶, 🐦]
+println!("{:?}", food); // [🍰, 🍔, 🍬]
 ```
 
 [zip](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.zip)


### PR DESCRIPTION
playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=eabdf778bf3063e24bb66104786a84d2

I don't know if there is a way to avoid `.cloned()`, but without it, it doesn't seem to compile.